### PR TITLE
fix syntax error in tt_scoreboard_ovi.sv

### DIFF
--- a/src/main/resources/vsrc/vpu/tt_scoreboard_ovi.sv
+++ b/src/main/resources/vsrc/vpu/tt_scoreboard_ovi.sv
@@ -164,7 +164,8 @@ module tt_scoreboard_ovi(input logic       clk,
 
   scoreboard_entry selected_entry;
   tt_ffs #(.WIDTH(32), //Number of inputs.
-          .DATA_WIDTH($bits(scoreboard_entry)))              //Width of data 
+          .DATA_WIDTH($bits(scoreboard_entry)))              //Width of data
+        tt_ffs_selected
         (.req_in(ready_to_drain),
           .data_in(scoreboard),
           .req_sum(o_drain_load_buffer), 
@@ -184,6 +185,7 @@ module tt_scoreboard_ovi(input logic       clk,
   scoreboard_entry completed_entry;
   tt_ffs #(.WIDTH(32),              //Number of inputs.
 		       .DATA_WIDTH($bits(scoreboard_entry)))              //Width of data 
+          tt_ffs_completed
           (.req_in(completed_entries),
            .data_in(scoreboard),
            .req_sum(o_completed_valid), 


### PR DESCRIPTION
<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: The verilator build fails because of an syntax error

<!-- choose one -->
**Type of change**: bug fix<!-- choose one -->
**Impact**: no rtl change 

<!-- choose one -->
**Development Phase**: proposal 

**Release Notes**
I don't know anything about hardware design, and verilog, but this seems to fix the build error I got when trying to build bobcat with verilator: `tt_scoreboard_ovi.sv:169:9: syntax error, unexpected '(', expecting IDENTIFIER or randomize`,...



